### PR TITLE
Tracing was stopped before start has been completed

### DIFF
--- a/src/tracingHandler.js
+++ b/src/tracingHandler.js
@@ -16,7 +16,7 @@ class TracingHandler {
       throw new Error('Browser is already being traced');
     }
     this.isTracing = true;
-    this._tracing.start({
+    return this._tracing.start({
       categories: categories.join(','),
       transferMode: 'ReturnAsStream'
     });
@@ -35,11 +35,11 @@ class TracingHandler {
     await this._tracing.tracingComplete(async event => {
       await this._readIOStream(event.stream).then(fulfill);
     });
-    return await this.traceEvents;
+    return this.traceEvents;
   }
 
-  async getTracingLogs() {
-    return await this.traceEvents;
+  getTracingLogs() {
+    return this.traceEvents;
   }
 
   async getSpeedIndex() {


### PR DESCRIPTION
# Issue

```
Tracing was stopped before start has been completed.

      at node_modules/chrome-remote-interface/lib/chrome.js:90:34
      at Chrome._handleMessage (node_modules/chrome-remote-interface/lib/chrome.js:252:17)
      at WebSocket.<anonymous> (node_modules/chrome-remote-interface/lib/chrome.js:230:22)
      at Receiver.receiverOnMessage (node_modules/chrome-remote-interface/node_modules/ws/lib/websocket.js:789:20)
      at Receiver.dataMessage (node_modules/chrome-remote-interface/node_modules/ws/lib/receiver.js:422:14)
      at node_modules/chrome-remote-interface/node_modules/ws/lib/receiver.js:379:23
      at node_modules/chrome-remote-interface/node_modules/ws/lib/permessage-deflate.js:298:9
      at node_modules/chrome-remote-interface/node_modules/ws/lib/permessage-deflate.js:376:7
```

# Fix

The `startTracing` method should return a `Promise`. Fixed the code to return a promise.

# Tests

```
npm run test

> taiko-diagnostics@0.3.0 test /Users/dphilip/GoogleDrive/workspace/taiko-diagnostics
> jest unit/__tests__/*.*.js --ci --reporters=default --reporters=jest-junit

 PASS  unit/__tests__/LogHandler.test.js
  ✓ Should invoke exceptionThrown callback with a listener function (3ms)
  ✓ Should invoke logger with appropriate log message when listener passed to exceptionThrown is invoked (1ms)
  ✓ Should invoke consoleAPI callback with a listener function
  ✓ Should invoke entryAdded callback with a listner function (1ms)
  ✓ Should invoke logger with appropriate log message when listener passed to entryAdded is invoked (1ms)

 Detected renderer thread by 'TracingStartedInBrowser' event: pid 28161, tid 775 
Failed to get timeToFirstInteractive due to "Your page took too long to load. Please follow the opportunities in the report to reduce your page load time, and then try re-running Lighthouse. ({errorCode})" 
 PASS  unit/__tests__/Tracing.test.js
  ✓ Start Tracing (3ms)
  ✓ End tracing throws if not tracing (1ms)
  ✓ getTracingLogs (1ms)
  ✓ get speed index (679ms)
  ✓ get performance metric (26ms)

Test Suites: 2 passed, 2 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        3.841s
Ran all test suites matching /unit\/__tests__\/LogHandler.test.js|unit\/__tests__\/Tracing.test.js/i.
```

Kindly publish a new package with the fix after merging