### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "files": [
     "lib"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/saikrishna321/taiko-diagnostics.git"
+  },
   "scripts": {
     "test": "jest unit/__tests__/*.*.js --ci --reporters=default --reporters=jest-junit",
     "integration": "npm run build && npm install -g . && TAIKO_PLUGIN='taiko-diagnostics' JEST_JUNIT_OUTPUT='./int-junit.xml' jest integration/__tests__/**.spec.js --ci --reporters=default --reporters=jest-junit",


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
* taiko-diagnostics